### PR TITLE
fix: use correct path in react subpage example

### DIFF
--- a/examples/react-mpa-app/src/pages/subpage/index.html
+++ b/examples/react-mpa-app/src/pages/subpage/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/pages/index/main.tsx"></script>
+    <script type="module" src="/src/pages/subpage/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Looks like copy pasta here, other examples seem to have the correct path tho 😄 