### PR TITLE
feat: support indexPage option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export default function mpa(userOptions: UserOptions = {}): Plugin {
     scanFile: 'main.{js,ts,jsx,tsx}',
     defaultEntries: '',
     filename: 'index.html',
+    indexPage: '',
     ...userOptions,
   }
   if (!options.scanFile.includes('.')) {
@@ -64,6 +65,11 @@ export default function mpa(userOptions: UserOptions = {}): Plugin {
       shell.mv(resolve(`${dest}/${options.scanDir}/*`), resolve(dest))
       // 4. remove empty src dir
       shell.rm('-rf', resolve(`${dest}/src`))
+      // 5. move the indexPage to dest root
+      if (options.indexPage) {
+        shell.mv(resolve(`${dest}/${options.indexPage}/index.html`), `${dest}/index.html`)
+        shell.rm('-rf', resolve(`${dest}/${options.indexPage}`))
+      }
     },
   }
 }

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -29,6 +29,11 @@ export interface MpaOptions {
    * @default ''
    */
   defaultEntries: string
+  /**
+   * the page will move to the root of the outDir
+   * @default false
+   */
+  indexPage: string | boolean
 }
 
 export type UserOptions = Partial<MpaOptions>


### PR DESCRIPTION
support a option named indexPage to move the specified page under scanDir to the root of outDir
支持名为indexPage的选项来将scanDir下的指定页面移动到打包后的根目录