### PR TITLE
fix: page-1 and page-10 are identified as the same

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -143,7 +143,7 @@ export function getHistoryReWriteRuleList(options: MpaOptions): Rewrite[] {
       to,
     })
     list.push({
-      from: new RegExp(`^/${pageName}/*`), // support pageName/{pages}
+      from: new RegExp(`^/${pageName}/`), // support pageName/{pages}
       to,
     })
   })


### PR DESCRIPTION
fix: page-1 and page-10 are identified as the same https://github.com/IndexXuan/vite-plugin-mpa/issues/26